### PR TITLE
fix: use stack to reliably order hooks

### DIFF
--- a/src/plugin-api/hooks/hook.js
+++ b/src/plugin-api/hooks/hook.js
@@ -83,7 +83,7 @@ export default class Hook {
 			.filter(v => !(v.before || v.after))
 			.map(({ name, value }) => ({ name, value }));
 		const needOrdering = this.rawValues.filter(v => v.before || v.after);
-		if (!needOrdering) {
+		if (needOrdering.length === 0) {
 			return orderedValues;
 		}
 		const stack = [ ...needOrdering ];

--- a/test/specs/plugin-api/test-hook.spec.js
+++ b/test/specs/plugin-api/test-hook.spec.js
@@ -36,34 +36,34 @@ describe('Hook', () => {
 		});
 
 		it('should insert at correct position using before option', () => {
-			hook.add('value1', { name: 'my-plugin1' });
-			hook.add('value2', { name: 'my-plugin2' });
 			hook.add('value3', { name: 'my-plugin3', before: 'my-plugin2' });
-			expect(hook.orderedRawValues).to.eql([
-				{ value: 'value1', name: 'my-plugin1' },
+			hook.add('value1', { name: 'my-plugin1' });
+			hook.add('value2', { name: 'my-plugin2', before: 'my-plugin1' });
+			expect(hook.orderedValues).to.eql([
 				{ value: 'value3', name: 'my-plugin3' },
-				{ value: 'value2', name: 'my-plugin2' }
+				{ value: 'value2', name: 'my-plugin2' },
+				{ value: 'value1', name: 'my-plugin1' }
 			]);
 			hook.add('value4', { name: 'my-plugin4', before: 'my-plugin1' });
-			expect(hook.orderedRawValues).to.eql([
-				{ value: 'value4', name: 'my-plugin4' },
-				{ value: 'value1', name: 'my-plugin1' },
+			expect(hook.orderedValues).to.eql([
 				{ value: 'value3', name: 'my-plugin3' },
-				{ value: 'value2', name: 'my-plugin2' }
+				{ value: 'value2', name: 'my-plugin2' },
+				{ value: 'value4', name: 'my-plugin4' },
+				{ value: 'value1', name: 'my-plugin1' }
 			]);
 		});
 
 		it('should insert at correct position using after option', () => {
+			hook.add('value3', { name: 'my-plugin3', after: 'my-plugin1' });
 			hook.add('value1', { name: 'my-plugin1' });
 			hook.add('value2', { name: 'my-plugin2' });
-			hook.add('value3', { name: 'my-plugin3', after: 'my-plugin1' });
-			expect(hook.orderedRawValues).to.eql([
+			expect(hook.orderedValues).to.eql([
 				{ value: 'value1', name: 'my-plugin1' },
 				{ value: 'value3', name: 'my-plugin3' },
 				{ value: 'value2', name: 'my-plugin2' }
 			]);
 			hook.add('value4', { name: 'my-plugin4', after: 'my-plugin2' });
-			expect(hook.orderedRawValues).to.eql([
+			expect(hook.orderedValues).to.eql([
 				{ value: 'value1', name: 'my-plugin1' },
 				{ value: 'value3', name: 'my-plugin3' },
 				{ value: 'value2', name: 'my-plugin2' },
@@ -75,9 +75,9 @@ describe('Hook', () => {
 			hook.add('value1', { name: 'my-plugin1' });
 			hook.add('value2', { name: 'my-plugin2' });
 			hook.add('value3', { name: 'my-plugin3', before: 'foo' });
-			expect(hook.orderedRawValues[2]).to.eql({ value: 'value3', name: 'my-plugin3' });
+			expect(hook.orderedValues[2]).to.eql({ value: 'value3', name: 'my-plugin3' });
 			hook.add('value4', { name: 'my-plugin4', after: 'foo' });
-			expect(hook.orderedRawValues[3]).to.eql({ value: 'value4', name: 'my-plugin4' });
+			expect(hook.orderedValues[3]).to.eql({ value: 'value4', name: 'my-plugin4' });
 		});
 	});
 


### PR DESCRIPTION
Using a simple for loop to order the hooks proved to be unreliable in certain use cases:

- Hook that registered at a later time.
- Tap before/after another hook, but that hook itself also requires a specific order.

This solves the issue by using a stack for items that need ordering, and pushing items back on the stack when the insert position cannot be determined the first time. Items are only pushed back one time on the stack to avoid possible before/after combination that are simply invalid. In that case items will pushed to the end and a warning will be emitted.