### PR TITLE
feat: add warning to highlight absolute require paths

### DIFF
--- a/src/config/base.js
+++ b/src/config/base.js
@@ -5,6 +5,8 @@ import path from 'path';
 import TerserPlugin from 'terser-webpack-plugin';
 
 import terserOptions from './terserOptions';
+import { formatAbsolutePathErrors } from '../utils/formatters';
+import { transformAbsolutePathErrors } from '../utils/transformers';
 
 export default (api, options) => {
 	const resolveLocal = (...args) => {
@@ -38,7 +40,13 @@ export default (api, options) => {
 
 		config.plugin('friendly-errors')
 			.use(FriendlyErrorsPlugin, [{
-				clearConsole: false
+				clearConsole: false,
+				additionalFormatters: [
+					formatAbsolutePathErrors
+				],
+				additionalTransformers: [
+					transformAbsolutePathErrors
+				]
 			}]);
 
 		// optimization ------------------------------------------------------------

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -36,6 +36,7 @@ export function formatAbsolutePathErrors (errors) {
 			grouped.length === 1 ? 'Absolute path require found' : 'Absolute path requires found',
 			'',
 			...grouped.map(formatGroup),
+			'',
 			'For absolute paths use the "@" alias at the start of your path to allow it to be resolved correctly',
 		];
 	}

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,0 +1,42 @@
+function group (errors) {
+	const modulePaths = new Map();
+
+	for (const error of errors) {
+		if (!modulePaths.has(error.module)) {
+			modulePaths.set(error.module, []);
+		}
+		modulePaths.get(error.module).push(error);
+	}
+
+	return Array.from(modulePaths.keys()).map(module => ({
+		module: module,
+		errors: modulePaths.get(module),
+	}));
+}
+
+function formatFileList (files) {
+	const length = files.length;
+	if (!length) {
+		return '';
+	}
+	return ` in ${files[0]}${files[1] ? `, ${files[1]}` : ''}${length > 2 ? ` and ${length - 2} other${length === 3 ? '' : 's'}` : ''}`;
+}
+
+function formatGroup (group) {
+	const files = group.errors.map(e => e.file).filter(Boolean);
+	return `* ${group.module} -> @${group.module}${formatFileList(files)}`;
+}
+
+export function formatAbsolutePathErrors (errors) {
+	const pathErrors = errors.filter(e => e.type === 'absolute-path-usage');
+	if (pathErrors.length > 0) {
+		// Firstly group related paths together
+		const grouped = group(pathErrors);
+		return [
+			grouped.length === 1 ? 'Absolute path require found' : 'Absolute path requires found',
+			'',
+			...grouped.map(formatGroup),
+			'For absolute paths use the "@" alias at the start of your path to allow it to be resolved correctly',
+		];
+	}
+}

--- a/src/utils/transformers.js
+++ b/src/utils/transformers.js
@@ -1,0 +1,8 @@
+export function transformAbsolutePathErrors (error) {
+	if (error.type === 'module-not-found' && error.module.startsWith('/')) {
+		error.type = 'absolute-path-usage';
+		error.message = `Absolute path used to require ${error.module}`;
+		error.name = 'Absolute path usage';
+	}
+	return error;
+}

--- a/test/specs/utils/test-formatters.spec.js
+++ b/test/specs/utils/test-formatters.spec.js
@@ -15,6 +15,7 @@ describe('utils - formatters', () => {
 				'Absolute path require found',
 				'',
 				'* /permissions -> @/permissions in ./app/controllers/phone/cameraGallery.js',
+				'',
 				'For absolute paths use the "@" alias at the start of your path to allow it to be resolved correctly',
 			]);
 		});
@@ -41,6 +42,7 @@ describe('utils - formatters', () => {
 				'',
 				'* /permissions -> @/permissions in ./app/controllers/phone/cameraGallery.js',
 				'* /awesome-module -> @/awesome-module in ./app/controllers/phone/test.js',
+				'',
 				'For absolute paths use the "@" alias at the start of your path to allow it to be resolved correctly',
 			]);
 		});
@@ -74,6 +76,7 @@ describe('utils - formatters', () => {
 				'Absolute path require found',
 				'',
 				'* /permissions -> @/permissions in ./app/controllers/phone/cameraGallery.js, ./app/controllers/phone/test.js and 1 other',
+				'',
 				'For absolute paths use the "@" alias at the start of your path to allow it to be resolved correctly',
 			]);
 		});

--- a/test/specs/utils/test-formatters.spec.js
+++ b/test/specs/utils/test-formatters.spec.js
@@ -1,0 +1,81 @@
+import { formatAbsolutePathErrors } from '../../../dist/utils/formatters';
+
+describe('utils - formatters', () => {
+	describe('formatAbsolutePathErrors', () => {
+		it('should format the error correctly for a single problem', () => {
+			expect(formatAbsolutePathErrors([{
+				message: 'Module not found /permissions',
+				file: './app/controllers/phone/cameraGallery.js',
+				origin: '\n @ ./app/controllers/phone/cameraGallery.js 193:4-27 264:4-27\n @ ./app/controllers sync ^\\.\\/.*$\n @ ./node_modules/alloy/Alloy/template/lib/alloy.js\n @ ./app/alloy.js\n @ multi ./app/alloy.js',
+				name: 'Module not found',
+				severity: 900,
+				type: 'absolute-path-usage',
+				module: '/permissions'
+			}])).to.deep.equal([
+				'Absolute path require found',
+				'',
+				'* /permissions -> @/permissions in ./app/controllers/phone/cameraGallery.js',
+				'For absolute paths use the "@" alias at the start of your path to allow it to be resolved correctly',
+			]);
+		});
+
+		it('should format the error correctly for multiple modules across different files', () => {
+			expect(formatAbsolutePathErrors([{
+				message: 'Module not found /permissions',
+				file: './app/controllers/phone/cameraGallery.js',
+				origin: '\n @ ./app/controllers/phone/cameraGallery.js 193:4-27 264:4-27\n @ ./app/controllers sync ^\\.\\/.*$\n @ ./node_modules/alloy/Alloy/template/lib/alloy.js\n @ ./app/alloy.js\n @ multi ./app/alloy.js',
+				name: 'Module not found',
+				severity: 900,
+				type: 'absolute-path-usage',
+				module: '/permissions'
+			}, {
+				message: 'Module not found /awesome-module',
+				file: './app/controllers/phone/test.js',
+				origin: '\n @ ./app/controllers/phone/test.js 193:4-27 264:4-27\n @ ./app/controllers sync ^\\.\\/.*$\n @ ./node_modules/alloy/Alloy/template/lib/alloy.js\n @ ./app/alloy.js\n @ multi ./app/alloy.js',
+				name: 'Module not found',
+				severity: 900,
+				type: 'absolute-path-usage',
+				module: '/awesome-module'
+			}])).to.deep.equal([
+				'Absolute path requires found',
+				'',
+				'* /permissions -> @/permissions in ./app/controllers/phone/cameraGallery.js',
+				'* /awesome-module -> @/awesome-module in ./app/controllers/phone/test.js',
+				'For absolute paths use the "@" alias at the start of your path to allow it to be resolved correctly',
+			]);
+		});
+
+		it('should format the error correctly for the same module in  different files', () => {
+			expect(formatAbsolutePathErrors([{
+				message: 'Module not found /permissions',
+				file: './app/controllers/phone/cameraGallery.js',
+				origin: '\n @ ./app/controllers/phone/cameraGallery.js 193:4-27 264:4-27\n @ ./app/controllers sync ^\\.\\/.*$\n @ ./node_modules/alloy/Alloy/template/lib/alloy.js\n @ ./app/alloy.js\n @ multi ./app/alloy.js',
+				name: 'Module not found',
+				severity: 900,
+				type: 'absolute-path-usage',
+				module: '/permissions'
+			}, {
+				message: 'Module not found /permissions',
+				file: './app/controllers/phone/test.js',
+				origin: '\n @ ./app/controllers/phone/test.js 193:4-27 264:4-27\n @ ./app/controllers sync ^\\.\\/.*$\n @ ./node_modules/alloy/Alloy/template/lib/alloy.js\n @ ./app/alloy.js\n @ multi ./app/alloy.js',
+				name: 'Module not found',
+				severity: 900,
+				type: 'absolute-path-usage',
+				module: '/permissions'
+			}, {
+				message: 'Module not found /permissions',
+				file: './app/controllers/phone/test2.js',
+				origin: '\n @ ./app/controllers/phone/test2.js 193:4-27 264:4-27\n @ ./app/controllers sync ^\\.\\/.*$\n @ ./node_modules/alloy/Alloy/template/lib/alloy.js\n @ ./app/alloy.js\n @ multi ./app/alloy.js',
+				name: 'Module not found',
+				severity: 900,
+				type: 'absolute-path-usage',
+				module: '/permissions'
+			}])).to.deep.equal([
+				'Absolute path require found',
+				'',
+				'* /permissions -> @/permissions in ./app/controllers/phone/cameraGallery.js, ./app/controllers/phone/test.js and 1 other',
+				'For absolute paths use the "@" alias at the start of your path to allow it to be resolved correctly',
+			]);
+		});
+	});
+});

--- a/test/specs/utils/test-transformers.spec.js
+++ b/test/specs/utils/test-transformers.spec.js
@@ -1,0 +1,47 @@
+import { transformAbsolutePathErrors } from '../../../dist/utils/transformers';
+
+let error;
+
+describe('utils - transformers', () => {
+	describe('transformAbsolutePathErrors', () => {
+		beforeEach(() => {
+			error = {
+				message: 'Module not found /permissions',
+				file: './app/controllers/phone/cameraGallery.js',
+				origin: '\n @ ./app/controllers/phone/cameraGallery.js 193:4-27 264:4-27\n @ ./app/controllers sync ^\\.\\/.*$\n @ ./node_modules/alloy/Alloy/template/lib/alloy.js\n @ ./app/alloy.js\n @ multi ./app/alloy.js',
+				name: 'Module not found',
+				severity: 900,
+				type: 'module-not-found',
+				module: '/permissions'
+			};
+		});
+
+		it('should transform module-not-found errors with absolute paths', () => {
+			expect(transformAbsolutePathErrors(error)).to.deep.equal({
+				message: 'Absolute path used to require /permissions',
+				file: './app/controllers/phone/cameraGallery.js',
+				origin: '\n @ ./app/controllers/phone/cameraGallery.js 193:4-27 264:4-27\n @ ./app/controllers sync ^\\.\\/.*$\n @ ./node_modules/alloy/Alloy/template/lib/alloy.js\n @ ./app/alloy.js\n @ multi ./app/alloy.js',
+				name: 'Absolute path usage',
+				severity: 900,
+				type: 'absolute-path-usage',
+				module: '/permissions'
+			});
+		});
+
+		it('should ignore non-absolute paths', () => {
+			const nonAbsoluteError = {
+				...error,
+				module: 'permissions'
+			};
+			expect(transformAbsolutePathErrors(nonAbsoluteError)).to.deep.equal(nonAbsoluteError);
+		});
+
+		it('should ignore other types of errors', () => {
+			const nonAbsoluteError = {
+				...error,
+				type: 'module-too-awesome'
+			};
+			expect(transformAbsolutePathErrors(nonAbsoluteError)).to.deep.equal(nonAbsoluteError);
+		});
+	});
+});


### PR DESCRIPTION
Add a custom error transformer and formatter that allows us to print friendly errors (mapped from "Module not found" errors) for when someone has kept a absolute path in a require rather than using the `@` alias. Prints the file the require is in and also the recommended change

```
[INFO]   WEBPACK   ERROR  Failed to compile with 5 errors2:17:14 PM
[INFO]   WEBPACK  
[INFO]   WEBPACK  Absolute path requires found
[INFO]   WEBPACK  
[INFO]   WEBPACK  * /actionbar -> @/actionbar in ./app/controllers/phone/audioRecorder.js
[INFO]   WEBPACK  * /logger -> @/logger in ./app/controllers/phone/audioRecorder.js
[INFO]   WEBPACK  * /permissions -> @/permissions in ./app/controllers/phone/audioRecorder.js, ./app/controllers/phone/cameraGallery.js and 1 other
[INFO]   WEBPACK  For absolute paths use the "@" alias at the start of your path to allow it to be resolved correctly
```