### PR TITLE
fix: handle windows exit code after stopping build

### DIFF
--- a/src/job/build-job.js
+++ b/src/job/build-job.js
@@ -255,10 +255,12 @@ export default class BuildJob extends EventEmitter {
 				}
 				case 'exit': {
 					this.pid = null;
-					if (data.code !== null && data.code !== 0) {
-						this.state = BuildJob.STATE_ERROR;
-					} else {
+					const code = data.code || 0;
+					const isWin = process.platform === 'win32';
+					if (code === 0 || (isWin && code === 1)) {
 						this.state = BuildJob.STATE_STOPPED;
+					} else {
+						this.state = BuildJob.STATE_ERROR;
 					}
 				}
 			}


### PR DESCRIPTION
on windows the exit code will always be 1 after killing the build subprocess

see https://github.com/libuv/libuv/blob/b2cec846efecc7ebb882234b5dc0b9a6690da461/src/win/process.c#L1203